### PR TITLE
Skip customers without Email

### DIFF
--- a/Nop.Plugin.Misc.MailChimp/Services/EventConsumer.cs
+++ b/Nop.Plugin.Misc.MailChimp/Services/EventConsumer.cs
@@ -146,7 +146,7 @@ namespace Nop.Plugin.Misc.MailChimp.Services
         /// <param name="eventMessage">Event message</param>
         public void HandleEvent(EntityInsertedEvent<Customer> eventMessage)
         {
-            if (eventMessage.Entity == null || _customerService.IsGuest(eventMessage.Entity))
+            if (eventMessage.Entity == null || _customerService.IsGuest(eventMessage.Entity) || string.IsNullOrEmpty(eventMessage.Entity?.Email))
                 return;
 
             AddRecord(EntityType.Customer, eventMessage.Entity.Id, OperationType.Create);


### PR DESCRIPTION
Skip to add customers(guest) without email in **MailChimpSynchronizationRecord**. 
When a new guest customer inserted into the database at that time there is no role assigned to a customer & that's why it adds this record for Mailchimp synchronization.